### PR TITLE
Handle missing language depots gracefully

### DIFF
--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -461,6 +461,9 @@ namespace DepotDownloader
 
                 if (depots != null)
                 {
+                    bool hasLanguageDepots = false;
+                    bool hasMatchingLanguageDepot = false;
+
                     foreach (var depotSection in depots.Children)
                     {
                         var id = INVALID_DEPOT_ID;
@@ -500,9 +503,11 @@ namespace DepotDownloader
                                     depotConfig["language"] != KeyValue.Invalid &&
                                     !string.IsNullOrWhiteSpace(depotConfig["language"].Value))
                                 {
+                                    hasLanguageDepots = true;
                                     var depotLang = depotConfig["language"].Value;
                                     if (depotLang != (language ?? "english"))
                                         continue;
+                                    hasMatchingLanguageDepot = true;
                                 }
 
                                 if (!lv &&
@@ -516,6 +521,20 @@ namespace DepotDownloader
 
                         if (!hasSpecificDepots)
                             depotManifestIds.Add((id, INVALID_MANIFEST_ID));
+                    }
+
+                    if (hasLanguageDepots && !hasMatchingLanguageDepot)
+                    {
+                        Console.WriteLine("No depots match requested language '{0}'.", language ?? "english");
+                        if (Config.MissingLanguageBehavior == MissingLanguageBehavior.FallbackToBase && depotManifestIds.Count > 0)
+                        {
+                            Console.WriteLine("Falling back to base depots.");
+                        }
+                        else
+                        {
+                            Console.WriteLine("Skipping download.");
+                            return;
+                        }
                     }
                 }
 

--- a/DepotDownloader/DownloadConfig.cs
+++ b/DepotDownloader/DownloadConfig.cs
@@ -6,6 +6,12 @@ using System.Text.RegularExpressions;
 
 namespace DepotDownloader
 {
+    enum MissingLanguageBehavior
+    {
+        Skip,
+        FallbackToBase,
+    }
+
     class DownloadConfig
     {
         public int CellID { get; set; }
@@ -32,5 +38,7 @@ namespace DepotDownloader
 
         public bool UseQrCode { get; set; }
         public bool SkipAppConfirmation { get; set; }
+
+        public MissingLanguageBehavior MissingLanguageBehavior { get; set; } = MissingLanguageBehavior.Skip;
     }
 }

--- a/DepotDownloader/Program.cs
+++ b/DepotDownloader/Program.cs
@@ -284,6 +284,21 @@ namespace DepotDownloader
                     return 1;
                 }
 
+                var missingLang = GetParameter<string>(args, "-missing-language");
+                switch (missingLang?.ToLowerInvariant())
+                {
+                    case "base":
+                        ContentDownloader.Config.MissingLanguageBehavior = MissingLanguageBehavior.FallbackToBase;
+                        break;
+                    case null:
+                    case "skip":
+                        ContentDownloader.Config.MissingLanguageBehavior = MissingLanguageBehavior.Skip;
+                        break;
+                    default:
+                        Console.WriteLine("Error: -missing-language must be 'base' or 'skip'.");
+                        return 1;
+                }
+
                 var lv = HasParameter(args, "-lowviolence");
 
                 var depotManifestIds = new List<(uint, ulong)>();

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Parameter               | Description
 `-all-archs`            | download all architecture-specific depots when `-app` is used.
 `-all-languages`        | download all language-specific depots when `-app` is used.
 `-language <lang>`      | the language for which to download the game (default: english)
+`-missing-language <base|skip>` | behaviour when requested language depots are missing: `base` to download non-language-specific depots, `skip` to exit without downloading (default: skip)
 `-lowviolence`          | download low violence depots when `-app` is used.
 `-dir <installdir>`     | the directory in which to place downloaded files.
 `-filelist <file.txt>`  | the name of a local file that contains a list of files to download (from the manifest). prefix file path with `regex:` if you want to match with regex. each file path should be on their own line.


### PR DESCRIPTION
## Summary
- allow optional fallback to base depots or skip when requested language depots are missing
- parse `-missing-language` CLI option and document in README
- provide user-friendly message instead of throwing when language depot absent

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0` *(failed: requires .NET SDK 9.0.100)*
- `dotnet build` *(failed: compatible .NET SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af60bb6dac832c913b6b6001613894