### PR TITLE
Add language-only depot download option

### DIFF
--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -496,7 +496,19 @@ namespace DepotDownloader
                                         continue;
                                 }
 
-                                if (!Config.DownloadAllLanguages &&
+                                if (Config.DownloadLanguagesOnly)
+                                {
+                                    if (depotConfig["language"] == KeyValue.Invalid || string.IsNullOrWhiteSpace(depotConfig["language"].Value))
+                                        continue;
+
+                                    if (!string.IsNullOrWhiteSpace(language))
+                                    {
+                                        var depotLang = depotConfig["language"].Value;
+                                        if (depotLang != language)
+                                            continue;
+                                    }
+                                }
+                                else if (!Config.DownloadAllLanguages &&
                                     depotConfig["language"] != KeyValue.Invalid &&
                                     !string.IsNullOrWhiteSpace(depotConfig["language"].Value))
                                 {

--- a/DepotDownloader/DownloadConfig.cs
+++ b/DepotDownloader/DownloadConfig.cs
@@ -12,6 +12,7 @@ namespace DepotDownloader
         public bool DownloadAllPlatforms { get; set; }
         public bool DownloadAllArchs { get; set; }
         public bool DownloadAllLanguages { get; set; }
+        public bool DownloadLanguagesOnly { get; set; }
         public bool DownloadManifestOnly { get; set; }
         public string InstallDirectory { get; set; }
 

--- a/DepotDownloader/Program.cs
+++ b/DepotDownloader/Program.cs
@@ -276,11 +276,18 @@ namespace DepotDownloader
                 }
 
                 ContentDownloader.Config.DownloadAllLanguages = HasParameter(args, "-all-languages");
+                ContentDownloader.Config.DownloadLanguagesOnly = HasParameter(args, "-languages-only");
                 var language = GetParameter<string>(args, "-language");
 
                 if (ContentDownloader.Config.DownloadAllLanguages && !string.IsNullOrEmpty(language))
                 {
                     Console.WriteLine("Error: Cannot specify -language when -all-languages is specified.");
+                    return 1;
+                }
+
+                if (ContentDownloader.Config.DownloadAllLanguages && ContentDownloader.Config.DownloadLanguagesOnly)
+                {
+                    Console.WriteLine("Error: Cannot specify -languages-only when -all-languages is specified.");
                     return 1;
                 }
 
@@ -506,6 +513,7 @@ namespace DepotDownloader
             Console.WriteLine("  -os <os>                 - the operating system for which to download the game (windows, macos or linux, default: OS the program is currently running on)");
             Console.WriteLine("  -osarch <arch>           - the architecture for which to download the game (32 or 64, default: the host's architecture)");
             Console.WriteLine("  -all-languages           - download all language-specific depots when -app is used.");
+            Console.WriteLine("  -languages-only          - download only language-specific depots when -app is used.");
             Console.WriteLine("  -language <lang>         - the language for which to download the game (default: english)");
             Console.WriteLine("  -lowviolence             - download low violence depots when -app is used.");
             Console.WriteLine();

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Parameter               | Description
 `-osarch <arch>`        | the architecture for which to download the game (32 or 64, default: the host's architecture)
 `-all-archs`            | download all architecture-specific depots when `-app` is used.
 `-all-languages`        | download all language-specific depots when `-app` is used.
+`-languages-only`       | download only language-specific depots when `-app` is used.
 `-language <lang>`      | the language for which to download the game (default: english)
 `-lowviolence`          | download low violence depots when `-app` is used.
 `-dir <installdir>`     | the directory in which to place downloaded files.
@@ -102,6 +103,12 @@ Parameter               | Description
 `-cellid <#>`           | the overridden CellID of the content server to download from.
 `-max-downloads <#>`    | maximum number of chunks to download concurrently. (default: 8).
 `-use-lancache`         | forces downloads over the local network via a Lancache instance.
+
+To download only a single language depot, combine `-languages-only` with `-language`:
+
+```
+./DepotDownloader -app <id> -languages-only -language <lang>
+```
 
 #### Other
 


### PR DESCRIPTION
## Summary
- allow combining `-languages-only` with `-language` without forcing all languages
- filter depots by requested language when `-languages-only` is specified
- document how to download a single language depot

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68af5aa93470832c89330eb1b94fec3c