### PR TITLE
Add flag to skip .DepotDownloader folders

### DIFF
--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -83,8 +83,11 @@ namespace DepotDownloader
                     installDir = baseDir;
                 }
 
-                Directory.CreateDirectory(Path.Combine(installDir, CONFIG_DIR));
-                Directory.CreateDirectory(Path.Combine(installDir, STAGING_DIR));
+                if (!Config.SkipDepotDownloaderDir)
+                {
+                    Directory.CreateDirectory(Path.Combine(installDir, CONFIG_DIR));
+                    Directory.CreateDirectory(Path.Combine(installDir, STAGING_DIR));
+                }
             }
             catch
             {
@@ -395,7 +398,9 @@ namespace DepotDownloader
                 return;
             }
 
-            var stagingDir = Path.Combine(installDir, STAGING_DIR);
+            var stagingDir = Config.SkipDepotDownloaderDir
+                ? Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+                : Path.Combine(installDir, STAGING_DIR);
             var fileStagingPath = Path.Combine(stagingDir, fileName);
             var fileFinalPath = Path.Combine(installDir, fileName);
 
@@ -786,7 +791,13 @@ namespace DepotDownloader
 
             DepotManifest oldManifest = null;
             DepotManifest newManifest = null;
-            var configDir = Path.Combine(depot.InstallDir, CONFIG_DIR);
+            var configDir = Config.SkipDepotDownloaderDir
+                ? Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+                : Path.Combine(depot.InstallDir, CONFIG_DIR);
+            if (Config.SkipDepotDownloaderDir)
+            {
+                Directory.CreateDirectory(configDir);
+            }
 
             var lastManifestId = INVALID_MANIFEST_ID;
             DepotConfigStore.Instance.InstalledManifestIDs.TryGetValue(depot.DepotId, out lastManifestId);
@@ -940,7 +951,9 @@ namespace DepotDownloader
                 return null;
             }
 
-            var stagingDir = Path.Combine(depot.InstallDir, STAGING_DIR);
+            var stagingDir = Config.SkipDepotDownloaderDir
+                ? Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+                : Path.Combine(depot.InstallDir, STAGING_DIR);
 
             var filesAfterExclusions = newManifest.Files.AsParallel().Where(f => TestIsFileIncluded(f.FileName)).ToList();
             var allFileNames = new HashSet<string>(filesAfterExclusions.Count);

--- a/DepotDownloader/DownloadConfig.cs
+++ b/DepotDownloader/DownloadConfig.cs
@@ -34,5 +34,6 @@ namespace DepotDownloader
 
         public bool UseQrCode { get; set; }
         public bool SkipAppConfirmation { get; set; }
+        public bool SkipDepotDownloaderDir { get; set; }
     }
 }

--- a/DepotDownloader/Program.cs
+++ b/DepotDownloader/Program.cs
@@ -137,6 +137,7 @@ namespace DepotDownloader
             ContentDownloader.Config.InstallDirectory = GetParameter<string>(args, "-dir");
 
             ContentDownloader.Config.VerifyAll = HasParameter(args, "-verify-all") || HasParameter(args, "-verify_all") || HasParameter(args, "-validate");
+            ContentDownloader.Config.SkipDepotDownloaderDir = HasParameter(args, "-skip-depotdownloader-dir");
 
             if (HasParameter(args, "-use-lancache"))
             {
@@ -530,6 +531,7 @@ namespace DepotDownloader
             Console.WriteLine("  -no-mobile               - prefer entering a 2FA code instead of prompting to accept in the Steam mobile app");
             Console.WriteLine();
             Console.WriteLine("  -dir <installdir>        - the directory in which to place downloaded files.");
+            Console.WriteLine("  -skip-depotdownloader-dir - do not create .DepotDownloader directories in the install folder.");
             Console.WriteLine("  -filelist <file.txt>     - the name of a local file that contains a list of files to download (from the manifest).");
             Console.WriteLine("                             prefix file path with `regex:` if you want to match with regex. each file path should be on their own line.");
             Console.WriteLine();

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Parameter               | Description
 `-language-diff`       | download language-specific depots that are not part of the base install.
 `-lowviolence`          | download low violence depots when `-app` is used.
 `-dir <installdir>`     | the directory in which to place downloaded files.
+`-skip-depotdownloader-dir` | do not create temporary `.DepotDownloader` directories in the install folder.
 `-filelist <file.txt>`  | the name of a local file that contains a list of files to download (from the manifest). prefix file path with `regex:` if you want to match with regex. each file path should be on their own line.
 `-validate`             | include checksum verification of files already downloaded.
 `-manifest-only`        | downloads a human readable manifest for any depots that would be downloaded.


### PR DESCRIPTION
## Summary
- allow skipping `.DepotDownloader` directory creation via `-skip-depotdownloader-dir`
- use temporary directories when flag is enabled
- document new option

## Testing
- `dotnet build` *(fails: A compatible .NET SDK was not found; Requested SDK version: 9.0.100)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e9adf500832c8827c39ba377a918