### PR TITLE
Fix build error and update for .NET 9

### DIFF
--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -461,7 +461,7 @@ namespace DepotDownloader
             var depots = GetSteam3AppSection(appId, EAppInfoSection.Depots);
             var depotLanguages = new Dictionary<uint, string>();
             var baseDepotIds = Config.LanguageSetDiff ? new HashSet<uint>() : null;
-            var candidateDepotLanguages = Config.LanguageSetDiff ? new Dictionary<uint, string>() : null
+            var candidateDepotLanguages = Config.LanguageSetDiff ? new Dictionary<uint, string>() : null;
 
             if (isUgc)
             {

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 DepotDownloader
 ===============
 
-Steam depot downloader utilizing the SteamKit2 library. Supports .NET 8.0
+Steam depot downloader utilizing the SteamKit2 library. Supports .NET 9.0
 
 This program must be run from a console, it has no GUI.
 


### PR DESCRIPTION
## Summary
- fix missing semicolon in ContentDownloader
- update README to reference .NET 9

## Testing
- `dotnet build DepotDownloader -c Release`
- `dotnet run --project DepotDownloader -c Release -- -V`


------
https://chatgpt.com/codex/tasks/task_e_68b6fe9d8ad8832c9a5061d7dd9209a7