### PR TITLE
Respect skip-depotdownloader-dir for config

### DIFF
--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -434,6 +434,11 @@ namespace DepotDownloader
                 configPath = DEFAULT_DOWNLOAD_DIR;
             }
 
+            if (Config.SkipDepotDownloaderDir)
+            {
+                configPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            }
+
             Directory.CreateDirectory(Path.Combine(configPath, CONFIG_DIR));
             DepotConfigStore.LoadFromFile(Path.Combine(configPath, CONFIG_DIR, "depot.config"));
 


### PR DESCRIPTION
## Summary
- Use a temporary path for depot config when `-skip-depotdownloader-dir` is specified to avoid leaving a `.DepotDownloader` folder in the install directory

## Testing
- `dotnet build`
- `dotnet test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b802668e24832cb7f90b1c78cd485a