### PR TITLE
Fix language depot deduplication across directories

### DIFF
--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -793,11 +793,19 @@ namespace DepotDownloader
             // This is in last-depot-wins order, from Steam or the list of depots supplied by the user
             if (!string.IsNullOrWhiteSpace(Config.InstallDirectory) && depotsToDownload.Count > 0)
             {
-                var claimedFileNames = new HashSet<string>();
+                var claimedFileNamesByDir = new Dictionary<string, HashSet<string>>();
 
                 for (var i = depotsToDownload.Count - 1; i >= 0; i--)
                 {
-                    // For each depot, remove all files from the list that have been claimed by a later depot
+                    var installDir = depotsToDownload[i].depotDownloadInfo.InstallDir;
+
+                    if (!claimedFileNamesByDir.TryGetValue(installDir, out var claimedFileNames))
+                    {
+                        claimedFileNames = new HashSet<string>();
+                        claimedFileNamesByDir[installDir] = claimedFileNames;
+                    }
+
+                    // For each depot, remove all files from the list that have been claimed by a later depot in the same directory
                     depotsToDownload[i].filteredFiles.RemoveAll(file => claimedFileNames.Contains(file.FileName));
 
                     claimedFileNames.UnionWith(depotsToDownload[i].allFileNames);


### PR DESCRIPTION
## Summary
- prevent cross-language depot deduplication by tracking claimed files per install directory

## Testing
- `dotnet build` *(fails: A compatible .NET SDK was not found; needs 9.0.100)*

------
https://chatgpt.com/codex/tasks/task_e_68c404234a88832c8a816677e46667c3