### PR TITLE
Fix language diff downloads including base depots

### DIFF
--- a/DepotDownloader/ContentDownloader.cs
+++ b/DepotDownloader/ContentDownloader.cs
@@ -539,10 +539,11 @@ namespace DepotDownloader
                                             string.IsNullOrWhiteSpace(depotConfig["language"].Value))
                                         {
                                             baseDepotIds.Add(id);
-                                            depotIdsFound.Add(id);
 
-                                            if (!hasSpecificDepots)
-                                                depotManifestIds.Add((id, INVALID_MANIFEST_ID));
+                                            if (hasSpecificDepots && depotIdsExpected.Contains(id))
+                                            {
+                                                depotIdsFound.Add(id);
+                                            }
 
                                             continue;
                                         }


### PR DESCRIPTION
## Summary
- stop automatically queuing base depots when using the language diff filter
- ensure only explicitly requested base depots are added when calculating language differences

## Testing
- `dotnet build` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9387f4230832cb10a3241886f4832